### PR TITLE
Feature/state reset except

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /dist
 /tmp
 /out-tsc
+/reports
 
 # dependencies
 /node_modules

--- a/README.md
+++ b/README.md
@@ -117,6 +117,32 @@ this.store.dispatch(
 );
 ```
 
+### How to Reset All States to Defaults
+
+To reset all states to their defaults:
+
+```TS
+this.store.dispatch(
+  new StateResetAll()
+);
+```
+
+To reset all states to their defaults but keep one:
+
+```TS
+this.store.dispatch(
+  new StateResetAll(SomeState)
+);
+```
+
+To reset all states to their defaults but keep some:
+
+```TS
+this.store.dispatch(
+  new StateResetAll(SomeState, SomeOtherState)
+);
+```
+
 ### How to Overwrite States
 
 To replace the value of a single state with a new one: \*
@@ -145,7 +171,9 @@ this.store.dispatch(
 
 - [x] Clear NGXS state(s) on dispatch of StateClear action
 
-- [x] Reset NGXS state(s) to defaults on dispatch of StateReset action
+- [x] Reset some NGXS state(s) to defaults on dispatch of StateReset action
+
+- [ ] Reset all NGXS states to defaults to on dispatch of StateResetAll action
 
 - [x] Overwrite NGXS state(s) on dispatch of StateOverwrite action
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ this.store.dispatch(
 
 ### How to Reset All States to Defaults
 
+**Important Notice:** Not tested on lazy loaded states. Use with caution.
+
 To reset all states to their defaults:
 
 ```TS
@@ -173,7 +175,7 @@ this.store.dispatch(
 
 - [x] Reset some NGXS state(s) to defaults on dispatch of StateReset action
 
-- [ ] Reset all NGXS states to defaults to on dispatch of StateResetAll action
+- [x] Reset all NGXS states to defaults to on dispatch of StateResetAll action
 
 - [x] Overwrite NGXS state(s) on dispatch of StateOverwrite action
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxs-reset-plugin",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/lib/internals.ts
+++ b/src/lib/internals.ts
@@ -3,38 +3,14 @@ import { MetaDataModel } from '@ngxs/store/src/internal/internals';
 export { MetaDataModel };
 
 /**
- * from @ngxs/store/src/utils/utils
- */
-export const setValue = (obj: any, prop: string, val: any) => {
-  obj = { ...obj };
-
-  const split = prop.split('.');
-  const lastIndex = split.length - 1;
-
-  split.reduce((acc, part, index) => {
-    if (index === lastIndex) {
-      acc[part] = val;
-    } else {
-      acc[part] = Array.isArray(acc[part]) ? [...acc[part]] : { ...acc[part] };
-    }
-
-    return acc && acc[part];
-  }, obj);
-
-  return obj;
-};
-
-/**
- * from @ngxs/store/src/utils/utils
- */
-export const getValue = (obj: any, prop: string): any =>
-  prop.split('.').reduce((acc: any, part: string) => acc && acc[part], obj);
-
-/**
  * a simplified implementation of NGXS StateClass interface
  */
 export interface StateClass<T = {}> {
   NGXS_META?: MetaDataModel;
 
   new (...args: any[]): T;
+}
+
+export function noop() {
+  return function() {};
 }

--- a/src/lib/reset.handler.ts
+++ b/src/lib/reset.handler.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { Actions, InitState, ofActionSuccessful, Store } from '@ngxs/store';
+import { take } from 'rxjs/operators';
+import { ResetService } from './reset.service';
+
+@Injectable()
+export class ResetHandler {
+  constructor(
+    private actions$: Actions,
+    private store: Store,
+    private resetService: ResetService,
+  ) {
+    this.actions$
+      .pipe(
+        ofActionSuccessful(InitState),
+        take(1),
+      )
+      .subscribe(() => (this.resetService.initialState = this.store.snapshot()));
+  }
+}

--- a/src/lib/reset.module.ts
+++ b/src/lib/reset.module.ts
@@ -1,6 +1,9 @@
-import { ModuleWithProviders, NgModule } from '@angular/core';
+import { APP_INITIALIZER, ModuleWithProviders, NgModule } from '@angular/core';
 import { NGXS_PLUGINS } from '@ngxs/store';
 import { NgxsResetPlugin } from './reset.plugin';
+import { ResetService } from './reset.service';
+import { ResetHandler } from './reset.handler';
+import { noop } from './internals';
 
 @NgModule()
 export class NgxsResetPluginModule {
@@ -8,12 +11,20 @@ export class NgxsResetPluginModule {
     return {
       ngModule: NgxsResetPluginModule,
       providers: [
+        ResetService,
+        ResetHandler,
+        {
+          provide: APP_INITIALIZER,
+          useFactory: noop,
+          deps: [ResetHandler],
+          multi: true,
+        },
         {
           provide: NGXS_PLUGINS,
           useClass: NgxsResetPlugin,
-          multi: true
-        }
-      ]
+          multi: true,
+        },
+      ],
     };
   }
 }

--- a/src/lib/reset.service.ts
+++ b/src/lib/reset.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class ResetService {
+  initialState: any;
+}

--- a/src/lib/symbols.ts
+++ b/src/lib/symbols.ts
@@ -36,6 +36,22 @@ export class StateReset {
 }
 
 /**
+ * Action to reset all states expect given state(s) to defaults
+ */
+export class StateResetAll {
+  public readonly statesToKeep: MetaDataModel[];
+  static readonly type = '@@RESET_STATE_ALL';
+
+  // The duplication is necessary for TypeScript
+  constructor(...statesToKeep: StateClass[]);
+  constructor();
+  constructor(...statesToKeep: StateClass[]) {
+    const reducer = createMetaDataListReducer(isDevMode());
+    this.statesToKeep = (statesToKeep || []).reduce<MetaDataModel[]>(reducer, []);
+  }
+}
+
+/**
  * Action to overwrite state(s) with given value(s)
  */
 export class StateOverwrite {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxs-reset-plugin",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-turkey/ngxs-reset-plugin.git"

--- a/src/tests/test-states.ts
+++ b/src/tests/test-states.ts
@@ -1,5 +1,13 @@
 import { Action, Selector, State, StateContext } from '@ngxs/store';
-import { App, Preferences, Session, SessionEnd, ToDo, ToDoAdd } from './test-symbols';
+import {
+  App,
+  Preferences,
+  PreferencesToggleDark,
+  Session,
+  SessionEnd,
+  ToDo,
+  ToDoAdd,
+} from './test-symbols';
 
 /**
  * Test ToDoState
@@ -41,7 +49,14 @@ export class ToDoState {
     language: 'en',
   },
 })
-export class PreferencesState {}
+export class PreferencesState {
+  @Action(PreferencesToggleDark)
+  toggleDark({ getState, patchState }: StateContext<Preferences.State>) {
+    patchState({
+      darkmode: !getState().darkmode,
+    });
+  }
+}
 
 /**
  * Test SessionState

--- a/src/tests/test-symbols.ts
+++ b/src/tests/test-symbols.ts
@@ -43,6 +43,13 @@ export namespace ToDo {
 }
 
 /**
+ * Test action to toggle darkmode
+ */
+export class PreferencesToggleDark {
+  static readonly type = '[Preferences] Toggle darkmode';
+}
+
+/**
  * Test action to add a lastseen timestamp
  */
 export class SessionEnd {


### PR DESCRIPTION
Solves #11 

This pull request provides a StateResetAll action to reset all states except given ones. Please refer to changes on README.md to see how it works.

Note: Lazy loaded states are not handled in this version. Instead, a notice is placed in the README file.